### PR TITLE
Replace `terra` prefix permissions by `geostore`

### DIFF
--- a/src/modules/CRUD/components/DataTable/CellRender/index.js
+++ b/src/modules/CRUD/components/DataTable/CellRender/index.js
@@ -9,7 +9,7 @@ export default connectAuthProvider(({
 }) => {
   const permissions = authenticated ? user.permissions : [];
   return {
-    displayViewFeature: permissions.includes('terra.view_feature'),
-    displayUpdateFeature: permissions.includes('terra.change_feature'),
+    displayViewFeature: permissions.includes('geostore.view_feature'),
+    displayUpdateFeature: permissions.includes('geostore.change_feature'),
   };
 })(CellRender);

--- a/src/modules/CRUD/components/DataTable/Header/index.js
+++ b/src/modules/CRUD/components/DataTable/Header/index.js
@@ -11,7 +11,7 @@ export default withRouter(
   }) => {
     const permissions = authenticated ? user.permissions : [];
     return {
-      displayAddFeature: permissions.includes('terra.add_feature'),
+      displayAddFeature: permissions.includes('geostore.add_feature'),
     };
   })(
     withNamespaces()(Header),

--- a/src/modules/CRUD/components/Details/Actions/index.js
+++ b/src/modules/CRUD/components/Details/Actions/index.js
@@ -14,8 +14,8 @@ export default withRouter(
   }, { displayUpdate, displayDelete }) => {
     const permissions = authenticated ? user.permissions : [];
     return {
-      displayDelete: displayDelete && permissions.includes('terra.delete_feature'),
-      displayUpdate: displayUpdate && permissions.includes('terra.change_feature'),
+      displayDelete: displayDelete && permissions.includes('geostore.delete_feature'),
+      displayUpdate: displayUpdate && permissions.includes('geostore.change_feature'),
     };
   })(
     connectCRUDProvider(({

--- a/src/modules/CRUD/components/Details/Edit/index.js
+++ b/src/modules/CRUD/components/Details/Edit/index.js
@@ -14,8 +14,8 @@ export default withRouter(
   }) => {
     const permissions = authenticated ? user.permissions : [];
     return {
-      displayAddFeature: permissions.includes('terra.add_feature'),
-      displayChangeFeature: permissions.includes('terra.change_feature'),
+      displayAddFeature: permissions.includes('geostore.add_feature'),
+      displayChangeFeature: permissions.includes('geostore.change_feature'),
     };
   })(
     connectCRUDProvider(({

--- a/src/modules/CRUD/components/Details/Read/index.js
+++ b/src/modules/CRUD/components/Details/Read/index.js
@@ -12,7 +12,7 @@ export default withRouter(
   }) => {
     const permissions = authenticated ? user.permissions : [];
     return {
-      displayViewFeature: permissions.includes('terra.view_feature'),
+      displayViewFeature: permissions.includes('geostore.view_feature'),
     };
   })(
     withNamespaces()(

--- a/src/modules/CRUD/views/Map/index.js
+++ b/src/modules/CRUD/views/Map/index.js
@@ -13,7 +13,7 @@ export default withRouter(
   }) => {
     const permissions = authenticated ? user.permissions : [];
     return {
-      displayViewFeature: permissions.includes('terra.view_feature'),
+      displayViewFeature: permissions.includes('geostore.view_feature'),
     };
   })(
     connectCRUDProvider(({


### PR DESCRIPTION
Since the split of geostore module from terra back, the prefix changes for this part. 