### PR TITLE
Downgrade bootstrap package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3996,9 +3996,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bootstrap": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+      "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
     },
     "brace": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@blueprintjs/datetime": "~3.13.0",
     "@blueprintjs/icons": "~3.10.0",
     "@terralego/core": "~1.6.5",
-    "bootstrap": "^4.3.1",
+    "bootstrap": "^3.3.7",
     "brace": "~0.11.1",
     "classnames": "^2.2.6",
     "final-form": "~4.18.5",

--- a/src/modules/CRUD/components/Details/Edit/Edit.js
+++ b/src/modules/CRUD/components/Details/Edit/Edit.js
@@ -322,7 +322,7 @@ class Edit extends React.Component {
         <div className="details__header">
           <h2 className="details__title">{mainTitle}</h2>
         </div>
-        <div className="details__content">
+        <div className="details__content bootstrap-inside">
           {properties
             ? (
               <Form

--- a/src/modules/CRUD/components/Details/Edit/__snapshots__/Edit.test.js.snap
+++ b/src/modules/CRUD/components/Details/Edit/__snapshots__/Edit.test.js.snap
@@ -20,7 +20,7 @@ exports[`Snapshots should render correctly 1`] = `
     </h2>
   </div>
   <div
-    className="details__content"
+    className="details__content bootstrap-inside"
   >
     <form>
       <div>
@@ -45,7 +45,7 @@ exports[`Snapshots should render correctly without schema props 1`] = `
     </h2>
   </div>
   <div
-    className="details__content"
+    className="details__content bootstrap-inside"
   >
     <div>
       Actions buttons

--- a/src/modules/CRUD/components/Details/styles.scss
+++ b/src/modules/CRUD/components/Details/styles.scss
@@ -128,7 +128,7 @@
     justify-content: flex-end;
     padding: 1rem 1rem 0;
     > * + * {
-      margin-left: 1rem;
+      margin-left: 1rem !important; // Cause of bootstrap override
       width: auto;
     }
     &-delete {
@@ -163,52 +163,12 @@
       overflow: auto;
     }
   }
+}
 
-
-  // Below from bootstrap
-  fieldset {
-    // Browsers set a default `min-width: min-content;` on fieldsets,
-    // unlike e.g. `<div>`s, which have `min-width: 0;` by default.
-    // So we reset that to ensure fieldsets behave more like a standard block element.
-    // See https://github.com/twbs/bootstrap/issues/12359
-    // and https://html.spec.whatwg.org/multipage/#the-fieldset-and-legend-elements 
-    min-width: 0;
-    // Reset the default outline behavior of fieldsets so they don't affect page layout.
-    padding: 0;
-    margin: 0;
-    border: 0;
-  }
-
+.bootstrap-inside {
+  @import "~bootstrap/dist/css/bootstrap.min";
   textarea {
     resize: vertical;
-  }
-
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .list-group {
-    margin-bottom: 1rem;
-  }
-
-  // Below from Bootstrap 3.3.6 because React-json-schema-form works fine with this version...
-  .checkbox,
-  .radio {
-    label {
-      min-height: 20px;
-      padding-left: 20px;
-      margin-bottom: 0;
-      font-weight: 400;
-      cursor: pointer;
-    }
-    input[type="checkbox"],
-    input[type="radio"] {
-      position: absolute;
-      margin-top: 2px;
-      margin-left: -20px;
-    }
   }
 }
 
@@ -223,10 +183,3 @@
     }
   }
 }
-
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/mixins";
-@import "~bootstrap/scss/utilities";
-@import "~bootstrap/scss/list-group";
-@import "~bootstrap/scss/forms";


### PR DESCRIPTION
> Every component from react-jsonschema-form works fine with the ui from bootstrap 3.3.7.
> At the beginning, i tried with the last version but there are too many components to rework in CSS.
> 
> One of the developper of RJSF started an issue about a support of bootstrap 4 [rjsf-team/react-jsonschema-form#1455](https://github.com/rjsf-team/react-jsonschema-form/issues/1455)

