### PR TITLE
Lock netlify-cli to version 2.40

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ Build:
     - mkdir ./tmp
     - mv ./build ./tmp/admin
     - mv ./tmp/admin/_* ./tmp
-    - npm i -g netlify-cli
+    - npm i -g netlify-cli@2.40
     - npx netlify deploy --site=$SITE_ID --auth=$NETLIFY_ACCESS_TOKEN  --dir=./tmp --prod
 
 Deploy Dev (force): &deploy_predev


### PR DESCRIPTION
As version 2.41.0 has [a reported issue](https://github.com/netlify/cli/issues/798), temporary locking to 2.40 allow to preserve deploying feature until Netlify fix it.