### PR TITLE
modules can be read in user attributes with terra-accounts > 1.0

### DIFF
--- a/src/hoc/withAppSettings.js
+++ b/src/hoc/withAppSettings.js
@@ -1,9 +1,18 @@
 import { connectAppProvider } from '../components/AppProvider';
 
+const enabledModulesGetter = ({ env: { enabled_modules: enabledModules } }) => (
+  enabledModules
+    ? { enabledModules }
+    : {}
+);
+
+// eslint-disable-next-line camelcase
+export const withEnabledModules_DEPRECATED = connectAppProvider(enabledModulesGetter);
 
 const mapConfigGetter = ({ env: { map, configMap = map } }) => ({ mapConfig: configMap });
 export const withMapConfig = connectAppProvider(mapConfigGetter);
 
 export default {
+  withEnabledModules_DEPRECATED,
   withMapConfig,
 };

--- a/src/hoc/withAppSettings.js
+++ b/src/hoc/withAppSettings.js
@@ -1,13 +1,9 @@
 import { connectAppProvider } from '../components/AppProvider';
 
-const enabledModulesGetter = ({ env: { enabled_modules: enabledModules } }) => ({ enabledModules });
-export const withEnabledModules = connectAppProvider(enabledModulesGetter);
-
 
 const mapConfigGetter = ({ env: { map, configMap = map } }) => ({ mapConfig: configMap });
 export const withMapConfig = connectAppProvider(mapConfigGetter);
 
 export default {
-  withEnabledModules,
   withMapConfig,
 };

--- a/src/hoc/withUserSettings.js
+++ b/src/hoc/withUserSettings.js
@@ -1,11 +1,10 @@
 import { connectAuthProvider } from '@terralego/core/modules/Auth';
-import { connectAppProvider } from '../components/AppProvider';
 
 const permissionsGetter = ({ user }) => (user ? { permissions: user.permissions } : {});
 export const withPermissions = connectAuthProvider(permissionsGetter);
 
 const enabledModulesGetter = ({ user }) => (user ? { enabled_modules: user.modules } : {});
-export const withEnabledModules = connectAppProvider(enabledModulesGetter);
+export const withEnabledModules = connectAuthProvider(enabledModulesGetter);
 
 export default {
   withEnabledModules,

--- a/src/hoc/withUserSettings.js
+++ b/src/hoc/withUserSettings.js
@@ -1,8 +1,13 @@
 import { connectAuthProvider } from '@terralego/core/modules/Auth';
+import { connectAppProvider } from '../components/AppProvider';
 
 const permissionsGetter = ({ user }) => (user ? { permissions: user.permissions } : {});
 export const withPermissions = connectAuthProvider(permissionsGetter);
 
+const enabledModulesGetter = ({ user }) => (user ? { enabled_modules: user.modules } : {});
+export const withEnabledModules = connectAppProvider(enabledModulesGetter);
+
 export default {
+  withEnabledModules,
   withPermissions,
 };

--- a/src/hoc/withUserSettings.js
+++ b/src/hoc/withUserSettings.js
@@ -1,12 +1,19 @@
 import { connectAuthProvider } from '@terralego/core/modules/Auth';
+import compose from '../utils/compose';
+// eslint-disable-next-line camelcase
+import { withEnabledModules_DEPRECATED } from './withAppSettings';
 
 const permissionsGetter = ({ user }) => (user ? { permissions: user.permissions } : {});
 export const withPermissions = connectAuthProvider(permissionsGetter);
 
-const enabledModulesGetter = ({ user }) => (user ? { enabled_modules: user.modules } : {});
-export const withEnabledModules = connectAuthProvider(enabledModulesGetter);
+const enabledModulesGetter = ({ user }) => (user ? { enabledModules: user.modules } : {});
+
+export const withEnabledModules = compose(
+  connectAuthProvider(enabledModulesGetter),
+  withEnabledModules_DEPRECATED,
+);
+
 
 export default {
-  withEnabledModules,
   withPermissions,
 };

--- a/src/modules/RA/RA.js
+++ b/src/modules/RA/RA.js
@@ -21,8 +21,7 @@ import { withLocale } from '../../components/Locale';
 import RALayout from '../../components/react-admin/Layout';
 
 import { resources } from './ra-modules';
-import { connectAppProvider } from '../../components/AppProvider';
-import { withPermissions } from '../../hoc/withUserSettings';
+import { withPermissions, withEnabledModules } from '../../hoc/withUserSettings';
 
 const sanitizeProps = ({ enpoint, moduleName, requiredPermissions, ...rest }) =>
   rest;
@@ -35,7 +34,7 @@ const customDataProvider = compose(
   enhanceDataProvider,
 )(dataProvider);
 
-export const CustomAdmin = ({ locale, permissions, allowedModules = [] }) => {
+export const CustomAdmin = ({ locale, permissions, enabledModules = [] }) => {
   const history = useHistory();
 
   const i18nProvider = React.useMemo(
@@ -47,7 +46,7 @@ export const CustomAdmin = ({ locale, permissions, allowedModules = [] }) => {
   const enabledResources = React.useMemo(
     () =>
       resources.filter(({ moduleName, requiredPermissions }) => {
-        if (!allowedModules.includes(moduleName)) {
+        if (!enabledModules.includes(moduleName)) {
           return false;
         }
         if (requiredPermissions && !permissions.includes[requiredPermissions]) {
@@ -56,7 +55,7 @@ export const CustomAdmin = ({ locale, permissions, allowedModules = [] }) => {
 
         return true;
       }),
-    [allowedModules, permissions],
+    [enabledModules, permissions],
   );
 
   if (!enabledResources.length) {
@@ -78,12 +77,8 @@ export const CustomAdmin = ({ locale, permissions, allowedModules = [] }) => {
   );
 };
 
-const componentsToDisplay = ({ env: { enabled_modules: allowedModules } }) => ({
-  allowedModules,
-});
-
 export default compose(
   withLocale,
   withPermissions,
-  connectAppProvider(componentsToDisplay),
+  withEnabledModules,
 )(CustomAdmin);

--- a/src/views/Main/Content/index.js
+++ b/src/views/Main/Content/index.js
@@ -1,6 +1,9 @@
+import { connectAuthProvider } from '@terralego/core/modules/Auth';
 import { connectAppProvider } from '../../../components/AppProvider';
+
 import { Content } from './Content';
 import { getComponentsByEnabledModules } from '../../../services/modules';
+import compose from '../../../utils/compose';
 
 
 const getDefaultRoute = landingModule => {
@@ -8,10 +11,18 @@ const getDefaultRoute = landingModule => {
   return path;
 };
 
-export default connectAppProvider(({
-  env: { enabled_modules: enabledModules, landing_module: landingModule },
+const setLandingModule = ({
+  env: { landing_module: landingModule },
 }) => ({
-  modules: getComponentsByEnabledModules(enabledModules),
   defaultRoute: getDefaultRoute(landingModule),
   landingModule,
-}))(Content);
+});
+
+const componentsToDisplay = ({ user: { modules } }) => ({
+  modules: getComponentsByEnabledModules(modules),
+});
+
+export default compose(
+  connectAppProvider(setLandingModule),
+  connectAuthProvider(componentsToDisplay),
+)(Content);

--- a/src/views/Main/MenuDropdown/index.js
+++ b/src/views/Main/MenuDropdown/index.js
@@ -4,7 +4,7 @@ import { getComponentsByEnabledModules } from '../../../services/modules';
 import { MenuDropdown } from './MenuDropdown';
 
 import compose from '../../../utils/compose';
-import { withEnabledModules } from '../../../hoc/withAppSettings';
+import { withEnabledModules } from '../../../hoc/withUserSettings';
 
 const componentsToDisplay = ({ env: { enabled_modules: modules } }) => ({
   modules: getComponentsByEnabledModules(modules),

--- a/src/views/Main/MenuDropdown/index.js
+++ b/src/views/Main/MenuDropdown/index.js
@@ -1,17 +1,17 @@
+import { connectAuthProvider } from '@terralego/core/modules/Auth';
 import { withTranslation } from 'react-i18next';
-import { connectAppProvider } from '../../../components/AppProvider';
 import { getComponentsByEnabledModules } from '../../../services/modules';
 import { MenuDropdown } from './MenuDropdown';
 
 import compose from '../../../utils/compose';
 import { withEnabledModules } from '../../../hoc/withUserSettings';
 
-const componentsToDisplay = ({ env: { enabled_modules: modules } }) => ({
+const componentsToDisplay = ({ user: { modules } }) => ({
   modules: getComponentsByEnabledModules(modules),
 });
 
 export default compose(
-  connectAppProvider(componentsToDisplay),
+  connectAuthProvider(componentsToDisplay),
   withTranslation(),
   withEnabledModules,
 )(MenuDropdown);

--- a/src/views/Summary/AppSummary/index.js
+++ b/src/views/Summary/AppSummary/index.js
@@ -6,8 +6,7 @@ import { withTranslation } from 'react-i18next';
 
 import { Tree } from '@blueprintjs/core';
 import compose from '../../../utils/compose';
-import { withPermissions } from '../../../hoc/withUserSettings';
-import { withEnabledModules } from '../../../hoc/withAppSettings';
+import { withPermissions, withEnabledModules } from '../../../hoc/withUserSettings';
 
 const byPermissions = permissions => ({ requiredPermissions }) => {
   if (!requiredPermissions) {


### PR DESCRIPTION
With this PR, the configuration to define which modules are displayed is driven by userSettings (i.e. from user JWT session).
The old version suffixed with DEPRECATED remains to support the previous version.
