### PR TITLE
Change default max categories to 100

### DIFF
--- a/src/modules/RA/DataLayer/components/tabs/StyleTab/Style/CategorizeValue.js
+++ b/src/modules/RA/DataLayer/components/tabs/StyleTab/Style/CategorizeValue.js
@@ -14,7 +14,7 @@ import styles from './styles';
 
 const useStyles = makeStyles(styles);
 
-const DEFAULT_MAX_CATEGORIES = 20;
+const DEFAULT_MAX_CATEGORIES = 100;
 
 const CategorizedValue = ({ path, category, Component }) => {
   const translate = useTranslate();


### PR DESCRIPTION
Don't know why the default was 20 so maybe we'll have to keep that in mind if we have perf issues.

100 doesn't seem *that* much, I've seen worse on a mapbox map